### PR TITLE
HAN-015: Fixed unwanted blank error toasts

### DIFF
--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -6,18 +6,9 @@ import { Input } from "@/components/ui/Input";
 import { Textarea } from "@/components/ui/TextArea";
 import { Button } from "@/components/ui/Button";
 import { handleContactForm } from "@/app/actions/handleContactForm";
-import { SESResult } from "@/lib/ses/classifyError";
 import { toast } from "sonner";
 
-const initialState: SESResult = {
-  success: false,
-  messageId: "",
-  errors: {},
-  errorCode: null,
-  userMessage: "",
-  internalMessage: "",
-  retryable: false,
-};
+const initialState = {};
 
 export default function ContactForm() {
   const [state, formAction, isPending] = useActionState(


### PR DESCRIPTION
This pull request includes a fix to the blank error toasts that appear whenever the contact page is navigated to. 

<h1>Before</h1>
<img width="1920" height="969" alt="image" src="https://github.com/user-attachments/assets/51d816bf-8ef3-41ad-b755-b095dee5a827" />
<br>
<h1>After</h1>
<img width="1920" height="1000" alt="image" src="https://github.com/user-attachments/assets/8e1a541c-362f-4875-991e-594544ddb83e" />
