### PR TITLE
[Hotfix] v1.0.2: fixed 500 errors in api response

### DIFF
--- a/src/app/api/route.ts
+++ b/src/app/api/route.ts
@@ -52,6 +52,7 @@ export async function POST(request: Request) {
       console.warn("200 Unrecognised Message Type");
       return NextResponse.json({ response: "200 Success" }, { status: 200 });
     }
+    return NextResponse.json({ response: "200 Success" }, { status: 200 });
   } catch {
     console.error({ message: "Payload not found" });
     return NextResponse.json(
@@ -69,6 +70,8 @@ async function validateHostname(signingCertURL: URL) {
     });
     return NextResponse.json({ response: "400 Bad Request" }, { status: 400 });
   }
+
+  return NextResponse.json({ response: "200 Valid Hostname" }, { status: 200 });
 }
 
 async function handleNotification(payload: SNSPayload) {
@@ -85,7 +88,10 @@ async function handleNotification(payload: SNSPayload) {
   if (message.notificationType === NotificationType.Bounce) {
     handleBounce(payload, message);
   }
-  return NextResponse.json({ response: "200 Success" }, { status: 200 });
+  return NextResponse.json(
+    { response: "200 Notification Handled" },
+    { status: 200 },
+  );
 }
 
 async function handleConfirmation(payload: SNSPayload) {
@@ -107,7 +113,10 @@ async function handleConfirmation(payload: SNSPayload) {
     );
   }
 
-  return NextResponse.json({ response: "200 Success" }, { status: 200 });
+  return NextResponse.json(
+    { response: "200 Confirmation Handled" },
+    { status: 200 },
+  );
 }
 
 async function fetchPEMCert(payload: SNSPayload) {
@@ -132,6 +141,11 @@ function verifyNotification(payload: SNSPayload, cert: string) {
     });
     return NextResponse.json({ response: "400 Bad Request" }, { status: 400 });
   }
+
+  return NextResponse.json(
+    { message: "200 Notification Verified" },
+    { status: 200 },
+  );
 }
 
 function verifyConfirmation(payload: SNSPayload, cert: string) {
@@ -147,6 +161,10 @@ function verifyConfirmation(payload: SNSPayload, cert: string) {
     });
     return NextResponse.json({ response: "400 Bad Request" }, { status: 400 });
   }
+  return NextResponse.json(
+    { message: "200 Confirmation Verified" },
+    { status: 200 },
+  );
 }
 
 async function handleComplaint(message: SESComplaintMessage) {
@@ -160,6 +178,10 @@ async function handleComplaint(message: SESComplaintMessage) {
 
     await client.send(command);
   }
+  return NextResponse.json(
+    { message: "200 Complaints Handled" },
+    { status: 200 },
+  );
 }
 
 async function handleBounce(payload: SNSPayload, message: SESBounceMessage) {
@@ -174,6 +196,10 @@ async function handleBounce(payload: SNSPayload, message: SESBounceMessage) {
 
       await client.send(command);
     }
+    return NextResponse.json(
+      { message: "200 Permanent Bounces Handled" },
+      { status: 200 },
+    );
   } else {
     const bouncedRecipients = message.bounce.bouncedRecipients;
 
@@ -190,6 +216,10 @@ async function handleBounce(payload: SNSPayload, message: SESBounceMessage) {
         originalMessageId: message.mail.messageId,
       });
     }
+    return NextResponse.json(
+      { message: "200 Temporary Bounces Handled" },
+      { status: 200 },
+    );
   }
 }
 


### PR DESCRIPTION
## Hotfix Summary
This hotfix stops the bounce/complaint handler returning a 500 response when a POST request is sent to the api from AWS SNS.

Hotfix branch: `v1.0.2` Target branch: `main`

## Severity
 Medium (significant but workaround exists)

## Related Issue(s) / Incident
Fixes #52 

## Root Cause
The absence of a 200 response at the end of successful handling blocks (mainly at the end of the try block) causes the bounce/complaint handler to not return any response codes after handling a POST request.

## Fix Description
200 responses were added to the end of handling logic branches and the overall try block.

## How to Test
After deploying to production:

1. Create an AWS account
2. Go to Amazon Simple Notification Service (SNS) and set up the topics "ses-complaints" and "ses-bounces"
3. Create subscriptions to ses-complaints and ses-bounces in SNS with the endpoint `https://han-tiet.com/api` and wait for them to be confirmed.
4. Create a @proton.me email account in Proton Mail
5. Set up and verify the @proton.me account as an identity in AWS Simple Email Service (SES)
6. Go to the dashboard for the identity and select Notifications, then edit the Feedback Notifications so that ses-bounces produces a bounce feedback and ses-complaints produces a complaint feedback. Include original headers with both options.
7. Go back to the identity dashboard and send a test email with a Bounce scenario and another with a Complaint scenario.
8. Check Vercel logs for a 200 POST response from `https://han-tiet.com/api`

## Risk Assessment
Risk level: Medium
Areas affected: Contacts page

## Rollback Plan
Redeploy v1.0.1 using Vercel

## Deployment Notes
None

## Post-Merge Actions
1.  Deploy to production
2.  Verify fix in production
3.  Merge/cherry-pick into develop
4.  Move #52 to completed

## Additional Context
None